### PR TITLE
chore: bump version to 2.1.0 (align with JS client)

### DIFF
--- a/ShipthisAPI/__init__.py
+++ b/ShipthisAPI/__init__.py
@@ -1,5 +1,5 @@
 # __variables__ with double-quoted values will be available in setup.py
-__version__ = "1.4.0"
+__version__ = "2.1.0"
 
 from .shipthisapi import (
     ShipthisAPI,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
      name='shipthisapi-python',  
-     version='1.4.0',
+     version='2.1.0',
      author="Mayur Rawte",
      author_email="mayur@shipthis.co",
      description="ShipthisAPI utility package",


### PR DESCRIPTION
## Summary

- Bump version from 1.4.0 to 2.1.0
- Aligns Python client version with JS client (shipthisapi-js v2.1.0)

## Test plan

- [ ] Verify package installs correctly
- [ ] Verify version is correctly reported