### PR TITLE
feat: add custom headers support, enhance patch_item

### DIFF
--- a/ShipthisAPI/__init__.py
+++ b/ShipthisAPI/__init__.py
@@ -1,5 +1,5 @@
 # __variables__ with double-quoted values will be available in setup.py
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 from .shipthisapi import (
     ShipthisAPI,

--- a/ShipthisAPI/shipthisapi.py
+++ b/ShipthisAPI/shipthisapi.py
@@ -5,21 +5,12 @@ A Python client for the Shipthis public API.
 Usage:
     from ShipthisAPI import ShipthisAPI
 
-    # Standard usage with API key
+    # Initialize the client
     client = ShipthisAPI(
         organisation="your_org_id",
         x_api_key="your_api_key",
         region_id="your_region",
         location_id="your_location"
-    )
-
-    # Server-to-server usage with custom headers
-    client = ShipthisAPI(
-        organisation="your_org_id",
-        custom_headers={
-            "st-server-key": "your_server_key",
-            "st-server-name": "your_service_name",
-        }
     )
 
     # Connect and validate

--- a/ShipthisAPI/shipthisapi.py
+++ b/ShipthisAPI/shipthisapi.py
@@ -483,16 +483,26 @@ class ShipthisAPI:
     ) -> Dict[str, Any]:
         """Patch specific fields of an item.
 
+        This is the recommended way to update document fields. It goes through
+        full field validation, workflow triggers, audit logging, and business logic.
+
         Args:
-            collection_name: Name of the collection.
+            collection_name: Name of the collection (e.g., "sea_shipment", "fcl_load").
             object_id: Document ID.
-            update_fields: Fields to update.
+            update_fields: Dictionary of field_id to value mappings.
 
         Returns:
             Updated document data.
 
         Raises:
             ShipthisAPIError: If the request fails.
+
+        Example:
+            client.patch_item(
+                "fcl_load",
+                "68a4f906743189ad061429a7",
+                update_fields={"container_no": "CONT123", "seal_no": "SEAL456"}
+            )
         """
         return self._make_request(
             "PATCH",
@@ -976,74 +986,6 @@ class ShipthisAPI:
         raise ShipthisRequestError(
             message=f"Upload failed with status {response.status_code}",
             status_code=response.status_code,
-        )
-
-    # ==================== Webhook Operations ====================
-
-    def webhook_sync(
-        self,
-        view_name: str,
-        doc_id: str,
-        fields: List[Dict[str, Any]],
-    ) -> Dict[str, Any]:
-        """Update document via webhook-sync (synchronous update).
-
-        Args:
-            view_name: View/collection name (e.g., "sea_shipment", "fcl_load").
-            doc_id: Document ID.
-            fields: List of field dicts to update.
-
-        Returns:
-            API response with success status and data.
-
-        Raises:
-            ShipthisAPIError: If the request fails.
-
-        Example:
-            client.webhook_sync(
-                "fcl_load",
-                "68a4f906743189ad061429a7",
-                fields=[{"container_no": "CONT123"}, {"seal_no": "SEAL456"}]
-            )
-        """
-        payload = {"fields": fields}
-        return self._make_request(
-            "PUT",
-            f"webhook-sync/{self.organisation_id}/{view_name}/{doc_id}",
-            request_data=payload,
-        )
-
-    def webhook_update(
-        self,
-        view_name: str,
-        doc_id: str,
-        actions: List[Dict[str, Any]],
-    ) -> Dict[str, Any]:
-        """Update document via webhook (async update with actions).
-
-        Args:
-            view_name: View/collection name.
-            doc_id: Document ID.
-            actions: List of action dicts to execute.
-
-        Returns:
-            API response with success status and data.
-
-        Raises:
-            ShipthisAPIError: If the request fails.
-
-        Example:
-            client.webhook_update(
-                "sea_shipment",
-                "68a4f906743189ad061429a7",
-                actions=[{"action": "update_status", "value": "completed"}]
-            )
-        """
-        payload = {"actions": actions}
-        return self._make_request(
-            "PUT",
-            f"webhook/{self.organisation_id}/{view_name}/{doc_id}",
-            request_data=payload,
         )
 
     # ==================== Reference Linked Fields ====================

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
      name='shipthisapi-python',  
-     version='2.1.0',
+     version='2.2.0',
      author="Mayur Rawte",
      author_email="mayur@shipthis.co",
      description="ShipthisAPI utility package",


### PR DESCRIPTION
## Summary
- Add `custom_headers` parameter for server-to-server auth override
- Make `x_api_key` optional (can use custom_headers instead)
- Add per-request header override support
- Enhance `patch_item` with better documentation as the recommended way to update fields
- Add `create_reference_linked_field` method
- Bump version to 2.2.0

## Usage
```python
from ShipthisAPI import ShipthisAPI

# Standard usage
client = ShipthisAPI(
    organisation="your_org_id",
    x_api_key="your_api_key"
)

# Patch document fields (recommended)
client.patch_item(
    "fcl_load",
    "68a4f906743189ad061429a7",
    update_fields={"container_no": "CONT123", "seal_no": "SEAL456"}
)
```

## Test plan
- [ ] Verify custom_headers work correctly
- [ ] Test patch_item updates fields as expected