### PR TITLE
chore: bump version to 3.0.2

### DIFF
--- a/ShipthisAPI/__init__.py
+++ b/ShipthisAPI/__init__.py
@@ -1,5 +1,5 @@
 # __variables__ with double-quoted values will be available in setup.py
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 
 from .shipthisapi import (
     ShipthisAPI,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
      name='shipthisapi-python',
-     version='3.0.0',
+     version='3.0.1',
      author="Mayur Rawte",
      author_email="mayur@shipthis.co",
      description="ShipthisAPI async utility package",


### PR DESCRIPTION
Version bump to 3.0.1 for PyPI release (3.0.0 was already published).