### PR TITLE
Fix/patch workflow key

### DIFF
--- a/ShipthisAPI/shipthisapi.py
+++ b/ShipthisAPI/shipthisapi.py
@@ -581,7 +581,7 @@ class ShipthisAPI:
         if update_fields is not None:
             request_data["update_fields"] = update_fields
         if workflow is not None:
-            request_data["workflow"] = workflow
+            request_data["workflows"] = workflow
         return await self._make_request(
             "PATCH",
             f"incollection/{collection_name}/{object_id}",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
      name='shipthisapi-python',
-     version='3.1.0',
+     version='3.1.1',
      author="Mayur Rawte",
      author_email="mayur@shipthis.co",
      description="ShipthisAPI async utility package",


### PR DESCRIPTION
## Summary
- Fixed `patch_item` sending `workflow` (singular) instead of `workflows` (plural) in the PATCH payload
- The backend endpoint expects `workflows` key — the mismatch caused workflow transitions to be silently ignored
- Bumped version to 3.1.1

## Test plan
- [ ] Call `patch_item` with `workflow=[{"workflow_id": "einvoice_state", "value": "submitted"}]`
- [ ] Verify the workflow transition is applied on the backend